### PR TITLE
use replace instead of insert to add extension

### DIFF
--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -99,7 +99,7 @@ where
 
                             for span_ref in path.into_iter() {
                                 let mut write_guard = span_ref.extensions_mut();
-                                write_guard.insert::<LazyTraceCtx<SpanId, TraceId>>(LazyTraceCtx(
+                                write_guard.replace::<LazyTraceCtx<SpanId, TraceId>>(LazyTraceCtx(
                                     TraceCtx {
                                         trace_id: local_trace_root.trace_id.clone(),
                                         parent_span: None,
@@ -122,7 +122,7 @@ where
 
                     for span_ref in path.into_iter() {
                         let mut write_guard = span_ref.extensions_mut();
-                        write_guard.insert::<LazyTraceCtx<SpanId, TraceId>>(LazyTraceCtx(
+                        write_guard.replace::<LazyTraceCtx<SpanId, TraceId>>(LazyTraceCtx(
                             TraceCtx {
                                 trace_id: already_evaluated.trace_id.clone(),
                                 parent_span: None,


### PR DESCRIPTION
Great work at fixing some issues with this crate!

We are looking at moving to your fork due to the inactivity in the main repository.
This PR has to do with an issue when registering extensions, see original PR for more information:

https://github.com/inanna-malick/tracing-honeycomb/pull/14

Please redirect me if I sumbitted this to the wrong branch.